### PR TITLE
Add Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: go
+
+services:
+  - docker
+
+script:
+  - make build

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ stop:
 build: gobuild dockbuild
 
 dockbuild:
-	[ -e ca-certificates.crt ] || curl https://curl.haxx.se/ca/cacert.pem -o ca-certificates.crt
+	[ -e ca-certificates.crt ] || curl -Lsf https://curl.haxx.se/ca/cacert.pem -o ca-certificates.crt
 	docker build -t ${registry}/${name}:${tag} .
 
 gobuild:


### PR DESCRIPTION
Adds the start of Travis-CI integration; builds a docker container. See https://travis-ci.org/jhmartin/key-manager for example output. I've verified that it detects a failed compile.  Travis is configured to use the golang build env, but that is ignored in favor of the docker run component. 

Further integration would be to configure Travis and the repo with a way to run some sort of test case, maybe provide a way to override the Instance ID normally guessed via the metadata system and provide a limited api key to Travis directly.